### PR TITLE
Release `0.1.0` preparation

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all-targets --features=test-utils
+          args: --all-targets
 
       - name: Build project
         uses: actions-rs/cargo@v1
@@ -96,14 +96,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all-targets --features=test-utils
+          args: --all-targets
 
       - name: Test project
         if: ${{ matrix.os != 'ubuntu-latest' || matrix.toolchain != 'nightly' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features=test-utils
 
       - name: Install kcov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.toolchain == 'nightly' }}
@@ -117,7 +116,7 @@ jobs:
           RUSTDOCFLAGS: '-Cdebuginfo=2 -Cinline-threshold=0 -Clink-dead-code'
         with:
           command: test
-          args: --no-run --features=test-utils
+          args: --no-run
 
       - name: Test with kcov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.toolchain == 'nightly' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+## [0.1.0] - 2021-01-12
 
 ### Added
 
-- `test-utils` feature for upstream tests
-- Initial commit
+- Serialization and deserialization of transactions.
+- Temporary deterministic wallet generation.
+- Implementation of `get_balance` and `public_spend_key`.
+- Preliminary implementation of `create_transfer_tx`.
+- Expose `NodeClient` and `Store` through FFI.
+- Define FFI and compile it only for WASM.
+- `NodeClient` and `Store` traits encapsulating host dependant functionality.
+- Initial commit.
+
+[Unreleased]: https://github.com/dusk-network/wallet-core/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/dusk-network/wallet-core/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,11 @@ dusk-schnorr = { version = "0.9.0-rc", default-features = false }
 dusk-jubjub = { version = "^0.10", default-features = false }
 dusk-poseidon = { version = "0.23.0-rc", features = [ "canon" ], default-features = false }
 dusk-plonk = { version = "^0.9", default-features = false }
-dusk-abi = "^0.9"
+rusk-abi = "0.5"
 canonical = "^0.6"
-blake2b_simd = { version = "^1.0", default-features = false }
 
 [dev-dependencies]
 rand = "^0.8"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[features]
-test-utils = []

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,6 +6,8 @@
 
 //! The foreign function interface for the wallet.
 
+use crate::POSEIDON_TREE_DEPTH;
+
 use alloc::vec::Vec;
 use core::num::NonZeroU32;
 use core::ptr;
@@ -22,7 +24,7 @@ use rand_core::{
     CryptoRng, RngCore,
 };
 
-use crate::{tx::UnprovenTransaction, POSEIDON_DEPTH};
+use crate::tx::UnprovenTransaction;
 use crate::{Error, NodeClient, Store, Wallet};
 
 extern "C" {
@@ -240,7 +242,7 @@ impl NodeClient for FfiNodeClient {
     fn fetch_opening(
         &self,
         note: &Note,
-    ) -> Result<PoseidonBranch<POSEIDON_DEPTH>, Self::Error> {
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error> {
         let mut opening_buf = [0u8; OPENING_BUF_SIZE];
 
         let mut opening_len = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,6 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(feature = "test-utils")]
-pub mod test_utils;
-
 #[cfg(target_family = "wasm")]
 mod ffi;
 
@@ -35,8 +32,7 @@ use sha2::{Digest, Sha256};
 pub use imp::*;
 pub use tx::{Transaction, UnprovenTransaction, UnprovenTransactionInput};
 
-/// The depth of an branch.
-pub const POSEIDON_DEPTH: usize = 17;
+pub use rusk_abi::POSEIDON_TREE_DEPTH;
 
 /// Stores the cryptographic material necessary to derive cryptographic keys.
 pub trait Store {
@@ -94,7 +90,7 @@ pub trait NodeClient {
     fn fetch_opening(
         &self,
         note: &Note,
-    ) -> Result<PoseidonBranch<POSEIDON_DEPTH>, Self::Error>;
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error>;
 
     /// Requests that a node prove the given transaction.
     fn request_proof(

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -4,16 +4,15 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Test utilities for use by crates upstream.
-
-use crate::{NodeClient, Store, UnprovenTransaction, Wallet, POSEIDON_DEPTH};
-
-use alloc::vec::Vec;
+//! Mocks of the traits supplied by the user of the crate..
 
 use dusk_jubjub::{BlsScalar, JubJubScalar};
 use dusk_pki::{PublicSpendKey, ViewKey};
 use dusk_plonk::prelude::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
+use dusk_wallet_core::{
+    NodeClient, Store, UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
+};
 use phoenix_core::{Note, NoteType};
 use rand_core::{CryptoRng, RngCore};
 
@@ -52,32 +51,6 @@ fn new_notes<Rng: RngCore + CryptoRng>(
         .collect()
 }
 
-/// Create a new wallet meant for tests, but wrapping the client in a custom
-/// implementation. The given client that will always return a random anchor
-/// (same every time), and the default opening.
-///
-/// The number of notes available is determined by `note_values`.
-pub fn mock_wallet_wrap_client<Rng, C, F>(
-    rng: &mut Rng,
-    note_values: &[u64],
-    f: F,
-) -> Wallet<TestStore, C>
-where
-    Rng: RngCore + CryptoRng,
-    C: NodeClient,
-    F: FnOnce(TestNodeClient) -> C,
-{
-    let store = TestStore::new(rng);
-    let psk = store.retrieve_key(0).unwrap().public_spend_key();
-
-    let notes = new_notes(rng, &psk, note_values);
-    let anchor = BlsScalar::random(rng);
-    let opening = Default::default();
-
-    let node = f(TestNodeClient::new(notes, anchor, opening));
-    Wallet::new(store, node)
-}
-
 /// An in-memory seed store.
 #[derive(Debug)]
 pub struct TestStore {
@@ -106,7 +79,7 @@ impl Store for TestStore {
 pub struct TestNodeClient {
     notes: Vec<Note>,
     anchor: BlsScalar,
-    opening: PoseidonBranch<POSEIDON_DEPTH>,
+    opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
 }
 
 impl TestNodeClient {
@@ -114,7 +87,7 @@ impl TestNodeClient {
     fn new(
         notes: Vec<Note>,
         anchor: BlsScalar,
-        opening: PoseidonBranch<POSEIDON_DEPTH>,
+        opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
     ) -> Self {
         Self {
             notes,
@@ -142,7 +115,7 @@ impl NodeClient for TestNodeClient {
     fn fetch_opening(
         &self,
         _: &Note,
-    ) -> Result<PoseidonBranch<POSEIDON_DEPTH>, Self::Error> {
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error> {
         Ok(self.opening.clone())
     }
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -6,13 +6,15 @@
 
 //! Wallet library tests.
 
+mod mock;
+
+use mock::{mock_wallet, TestNodeClient};
+
 use dusk_pki::ViewKey;
 use dusk_plonk::prelude::{BlsScalar, Proof};
 use dusk_poseidon::tree::PoseidonBranch;
-use dusk_wallet_core::test_utils::mock_wallet;
 use dusk_wallet_core::{
-    test_utils::TestNodeClient, NodeClient, Transaction, UnprovenTransaction,
-    POSEIDON_DEPTH,
+    NodeClient, Transaction, UnprovenTransaction, POSEIDON_TREE_DEPTH,
 };
 use phoenix_core::Note;
 
@@ -39,7 +41,7 @@ impl NodeClient for SerdeNodeClient {
     fn fetch_opening(
         &self,
         note: &Note,
-    ) -> Result<PoseidonBranch<POSEIDON_DEPTH>, Self::Error> {
+    ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error> {
         self.node.fetch_opening(note)
     }
 


### PR DESCRIPTION
This PR prepares the crate for its first release.

It doesn't have everything implemented - or in no way is what is already implemented complete. It just makes sense to unblock upstream, specifically the [prover service PR](https://github.com/dusk-network/rusk/pull/403).