### PR TITLE
Implement staking transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MPL-2.0"
 rand_core = "^0.6"
 rand_chacha = { version = "^0.3", default-features = false }
 sha2 = { version = "^0.10", default-features = false }
-phoenix-core = "0.15.0-rc"
-dusk-pki = "0.9.0-rc"
+phoenix-core = { version =  "0.15.0-rc", features = [ "canon" ] }
+dusk-pki = { version = "0.9.0-rc", features = [ "canon" ] }
 dusk-bytes = "^0.1"
 dusk-schnorr = { version = "0.9.0-rc", default-features = false }
 dusk-jubjub = { version = "^0.10", default-features = false }

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -5,26 +5,32 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::tx::UnprovenTransaction;
-use crate::{NodeClient, Store};
+use crate::{ProverClient, StateClient, Store};
 
 use alloc::vec::Vec;
 
 use canonical::CanonError;
-use dusk_bytes::Error as BytesError;
+use canonical::EncodeToVec;
+use dusk_bytes::{Error as BytesError, Serializable};
 use dusk_jubjub::{BlsScalar, JubJubScalar};
-use dusk_pki::PublicSpendKey;
+use dusk_pki::{PublicKey, PublicSpendKey, SecretSpendKey};
+use dusk_poseidon::sponge;
+use dusk_schnorr::Signature;
 use phoenix_core::{Crossover, Error as PhoenixError, Fee, Note, NoteType};
 use rand_core::{CryptoRng, Error as RngError, RngCore};
+use rusk_abi::ContractId;
 
 const MAX_INPUT_NOTES: usize = 4;
 
 /// The error type returned by this crate.
 #[derive(Debug)]
-pub enum Error<S: Store, C: NodeClient> {
+pub enum Error<S: Store, SC: StateClient, PC: ProverClient> {
     /// Underlying store error.
     Store(S::Error),
-    /// Error originating from the node client.
-    Node(C::Error),
+    /// Error originating from the state client.
+    State(SC::Error),
+    /// Error originating from the prover client.
+    Prover(PC::Error),
     /// Canonical stores.
     Canon(CanonError),
     /// Random number generator error.
@@ -40,36 +46,48 @@ pub enum Error<S: Store, C: NodeClient> {
     NoteCombinationProblem,
 }
 
-impl<S: Store, C: NodeClient> Error<S, C> {
+impl<S: Store, SC: StateClient, PC: ProverClient> Error<S, SC, PC> {
     /// Returns an error from the underlying store error.
     pub fn from_store_err(se: S::Error) -> Self {
         Self::Store(se)
     }
-    /// Returns an error from the underlying note finder error.
-    pub fn from_node_err(ne: C::Error) -> Self {
-        Self::Node(ne)
+    /// Returns an error from the underlying state client.
+    pub fn from_state_err(se: SC::Error) -> Self {
+        Self::State(se)
+    }
+    /// Returns an error from the underlying prover client.
+    pub fn from_prover_err(pe: PC::Error) -> Self {
+        Self::Prover(pe)
     }
 }
 
-impl<S: Store, C: NodeClient> From<RngError> for Error<S, C> {
+impl<S: Store, SC: StateClient, PC: ProverClient> From<RngError>
+    for Error<S, SC, PC>
+{
     fn from(re: RngError) -> Self {
         Self::Rng(re)
     }
 }
 
-impl<S: Store, C: NodeClient> From<BytesError> for Error<S, C> {
+impl<S: Store, SC: StateClient, PC: ProverClient> From<BytesError>
+    for Error<S, SC, PC>
+{
     fn from(be: BytesError) -> Self {
         Self::Bytes(be)
     }
 }
 
-impl<S: Store, C: NodeClient> From<PhoenixError> for Error<S, C> {
+impl<S: Store, SC: StateClient, PC: ProverClient> From<PhoenixError>
+    for Error<S, SC, PC>
+{
     fn from(pe: PhoenixError) -> Self {
         Self::Phoenix(pe)
     }
 }
 
-impl<S: Store, C: NodeClient> From<CanonError> for Error<S, C> {
+impl<S: Store, SC: StateClient, PC: ProverClient> From<CanonError>
+    for Error<S, SC, PC>
+{
     fn from(ce: CanonError) -> Self {
         Self::Canon(ce)
     }
@@ -79,37 +97,113 @@ impl<S: Store, C: NodeClient> From<CanonError> for Error<S, C> {
 ///
 /// This is responsible for holding the keys, and performing operations like
 /// creating transactions.
-pub struct Wallet<S, C> {
+pub struct Wallet<S, SC, PC> {
     store: S,
-    node: C,
+    state: SC,
+    prover: PC,
 }
 
-impl<S, C> Wallet<S, C> {
+impl<S, SC, PC> Wallet<S, SC, PC> {
     /// Create a new wallet given the underlying store and node client.
-    pub const fn new(store: S, node: C) -> Self {
-        Self { store, node }
+    pub const fn new(store: S, state: SC, prover: PC) -> Self {
+        Self {
+            store,
+            state,
+            prover,
+        }
     }
 }
 
-impl<S, C> Wallet<S, C>
+const TX_STAKE: u8 = 0x00;
+const TX_EXTEND: u8 = 0x01;
+const TX_WITHDRAW: u8 = 0x02;
+
+impl<S, SC, PC> Wallet<S, SC, PC>
 where
     S: Store,
-    C: NodeClient,
+    SC: StateClient,
+    PC: ProverClient,
 {
     /// Retrieve the public spend key with the given index.
     pub fn public_spend_key(
         &self,
         index: u64,
-    ) -> Result<PublicSpendKey, Error<S, C>> {
+    ) -> Result<PublicSpendKey, Error<S, SC, PC>> {
         self.store
-            .retrieve_key(index)
+            .retrieve_ssk(index)
             .map(|ssk| ssk.public_spend_key())
             .map_err(Error::from_store_err)
     }
 
-    /// Creates a transfer transaction.
+    /// Retrieve the public key with the given index.
+    pub fn public_key(
+        &self,
+        index: u64,
+    ) -> Result<PublicKey, Error<S, SC, PC>> {
+        self.store
+            .retrieve_sk(index)
+            .map(|sk| From::from(&sk))
+            .map_err(Error::from_store_err)
+    }
+
+    /// Here we fetch the notes and perform a "minimum number of notes
+    /// required" algorithm to select which ones to use for this TX. This is
+    /// done by picking notes largest to smallest until they combined have
+    /// enough accumulated value.
+    #[allow(clippy::type_complexity)]
+    fn minimum_inputs_with_value(
+        &self,
+        sender: &SecretSpendKey,
+        value: u64,
+    ) -> Result<Vec<(Note, u64, JubJubScalar)>, Error<S, SC, PC>> {
+        let sender_vk = sender.view_key();
+
+        // TODO find a way to get the block height from somewhere. Maybe it
+        //  should be determined by the client?
+        let mut notes = self
+            .state
+            .fetch_notes(0, &sender_vk)
+            .map_err(Error::from_state_err)?;
+        let mut notes_and_values = Vec::with_capacity(notes.len());
+
+        let mut accumulated_value = 0;
+        for note in notes.drain(..) {
+            let val = note.value(Some(&sender_vk))?;
+            let blinder = note.blinding_factor(Some(&sender_vk))?;
+            accumulated_value += val;
+            notes_and_values.push((note, val, blinder));
+        }
+
+        if accumulated_value < value {
+            return Err(Error::NotEnoughBalance);
+        }
+
+        // This sorts the notes from least valuable to most valuable. It
+        // helps in the minimum gas spent algorithm, where the largest notes
+        // are "popped" first.
+        notes_and_values.sort_by(|(_, aval, _), (_, bval, _)| aval.cmp(bval));
+
+        let mut input_notes = Vec::with_capacity(notes.len());
+
+        let mut accumulated_value = 0;
+        while accumulated_value < value {
+            // This unwrap is ok because at this point we can be sure there
+            // is enough value in the notes.
+            let (note, val, blinder) = notes_and_values.pop().unwrap();
+            accumulated_value += val;
+            input_notes.push((note, val, blinder));
+        }
+
+        if input_notes.len() > MAX_INPUT_NOTES {
+            return Err(Error::NoteCombinationProblem);
+        }
+
+        Ok(input_notes)
+    }
+
+    /// Transfer Dusk from one key to another.
     #[allow(clippy::too_many_arguments)]
-    pub fn create_transfer_tx<Rng: RngCore + CryptoRng>(
+    pub fn transfer<Rng: RngCore + CryptoRng>(
         &self,
         rng: &mut Rng,
         sender_index: u64,
@@ -119,62 +213,16 @@ where
         gas_limit: u64,
         gas_price: u64,
         ref_id: BlsScalar,
-    ) -> Result<(), Error<S, C>> {
+    ) -> Result<(), Error<S, SC, PC>> {
         let sender = self
             .store
-            .retrieve_key(sender_index)
+            .retrieve_ssk(sender_index)
             .map_err(Error::from_store_err)?;
 
-        // Here we fetch the notes and perform a "minimum number of notes
-        // required" algorithm to select which ones to use for this TX. This is
-        // done by picking notes largest to smallest until they combined have
-        // enough accumulated value.
-        let inputs = {
-            let sender_vk = sender.view_key();
-
-            // TODO find a way to get the block height from somewhere. Maybe it
-            //  should be determined by the client?
-            let mut notes = self
-                .node
-                .fetch_notes(0, &sender_vk)
-                .map_err(Error::from_node_err)?;
-            let mut notes_and_values = Vec::with_capacity(notes.len());
-
-            let mut accumulated_value = 0;
-            for note in notes.drain(..) {
-                let val = note.value(Some(&sender_vk))?;
-                let blinder = note.blinding_factor(Some(&sender_vk))?;
-                accumulated_value += val;
-                notes_and_values.push((note, val, blinder));
-            }
-
-            if accumulated_value < value {
-                return Err(Error::NotEnoughBalance);
-            }
-
-            // This sorts the notes from least valuable to most valuable. It
-            // helps in the minimum gas spent algorithm, where the largest notes
-            // are "popped" first.
-            notes_and_values
-                .sort_by(|(_, aval, _), (_, bval, _)| aval.cmp(bval));
-
-            let mut input_notes = Vec::with_capacity(notes.len());
-
-            let mut accumulated_value = 0;
-            while accumulated_value < value {
-                // This unwrap is ok because at this point we can be sure there
-                // is enough value in the notes.
-                let (note, val, blinder) = notes_and_values.pop().unwrap();
-                accumulated_value += val;
-                input_notes.push((note, val, blinder));
-            }
-
-            if input_notes.len() > MAX_INPUT_NOTES {
-                return Err(Error::NoteCombinationProblem);
-            }
-
-            input_notes
-        };
+        let inputs = self.minimum_inputs_with_value(
+            &sender,
+            value + gas_limit * gas_price,
+        )?;
 
         let (output_note, output_blinder) =
             generate_obfuscated_note(rng, receiver, value, ref_id);
@@ -188,57 +236,256 @@ where
 
         let crossover = zero_crossover(rng);
         let fee = Fee::new(rng, gas_limit, gas_price, refund);
-        let anchor = self.node.fetch_anchor().map_err(Error::from_node_err)?;
 
         let utx = UnprovenTransaction::new(
-            rng, &self.node, &sender, inputs, outputs, anchor, fee, crossover,
+            rng,
+            &self.state,
+            &sender,
+            inputs,
+            outputs,
+            fee,
+            crossover,
             None,
         )
-        .map_err(Error::from_node_err)?;
+        .map_err(Error::from_state_err)?;
 
-        self.node
+        self.prover
             .compute_proof_and_propagate(&utx)
-            .map_err(Error::from_node_err)?;
+            .map_err(Error::from_prover_err)?;
         Ok(())
     }
 
-    /// Creates a stake transaction.
-    pub fn create_stake_tx(&self) -> Result<(), Error<S, C>> {
-        unimplemented!()
-    }
+    /// Stakes an amount of Dusk.
+    #[allow(clippy::too_many_arguments)]
+    pub fn stake<Rng: RngCore + CryptoRng>(
+        &self,
+        rng: &mut Rng,
+        sender_index: u64,
+        staker_index: u64,
+        refund: &PublicSpendKey,
+        value: u64,
+        gas_limit: u64,
+        gas_price: u64,
+    ) -> Result<(), Error<S, SC, PC>> {
+        let sender = self
+            .store
+            .retrieve_ssk(sender_index)
+            .map_err(Error::from_store_err)?;
 
-    /// Stops staking for a key.
-    pub fn stop_stake(&self) -> Result<(), Error<S, C>> {
-        unimplemented!()
+        let inputs = self.minimum_inputs_with_value(
+            &sender,
+            value + gas_limit * gas_price,
+        )?;
+
+        // There's no outputs in a stake transaction.
+        let outputs = vec![];
+
+        let fee = Fee::new(rng, gas_limit, gas_price, refund);
+
+        let blinder = JubJubScalar::random(rng);
+        let note =
+            Note::obfuscated(rng, &sender.public_spend_key(), value, blinder);
+        let (_, crossover) = note
+            .try_into()
+            .expect("Obfuscated notes should always yield crossovers");
+
+        let sk = self
+            .store
+            .retrieve_sk(staker_index)
+            .map_err(Error::from_store_err)?;
+        let pk = PublicKey::from(&sk);
+
+        let contract_id = rusk_abi::stake_contract();
+        let address = contract_to_scalar(&contract_id);
+
+        let mut m = crossover.to_hash_inputs().to_vec();
+        m.push(value.into());
+        m.push(address);
+
+        let signature = Signature::new(&sk, rng, sponge::hash(&m));
+
+        let spend_proof = self
+            .prover
+            .request_stct_proof(
+                &fee, &crossover, value, blinder, address, signature,
+            )
+            .map_err(Error::from_prover_err)?;
+
+        let call_data =
+            (TX_STAKE, pk, value, spend_proof.to_bytes()).encode_to_vec();
+
+        let call = (contract_id, call_data);
+
+        let utx = UnprovenTransaction::new(
+            rng,
+            &self.state,
+            &sender,
+            inputs,
+            outputs,
+            fee,
+            (crossover, value, blinder),
+            Some(call),
+        )
+        .map_err(Error::from_state_err)?;
+
+        self.prover
+            .compute_proof_and_propagate(&utx)
+            .map_err(Error::from_prover_err)?;
+        Ok(())
     }
 
     /// Extends staking for a particular key.
-    pub fn extend_stake(&self) -> Result<(), Error<S, C>> {
-        unimplemented!()
+    pub fn extend_stake<Rng: RngCore + CryptoRng>(
+        &self,
+        rng: &mut Rng,
+        sender_index: u64,
+        staker_index: u64,
+        refund: &PublicSpendKey,
+        gas_limit: u64,
+        gas_price: u64,
+    ) -> Result<(), Error<S, SC, PC>> {
+        let sender = self
+            .store
+            .retrieve_ssk(sender_index)
+            .map_err(Error::from_store_err)?;
+
+        let inputs =
+            self.minimum_inputs_with_value(&sender, gas_limit * gas_price)?;
+
+        // There's no outputs in an extend stake transaction.
+        let outputs = vec![];
+
+        let fee = Fee::new(rng, gas_limit, gas_price, refund);
+
+        let (crossover, value, blinder) = zero_crossover(rng);
+
+        let sk = self
+            .store
+            .retrieve_sk(staker_index)
+            .map_err(Error::from_store_err)?;
+        let pk = PublicKey::from(&sk);
+
+        let (_, expiration) =
+            self.state.fetch_stake(&pk).map_err(Error::from_state_err)?;
+        let expiration = BlsScalar::from(expiration as u64);
+        let signature = Signature::new(&sk, rng, expiration);
+
+        let contract_id = rusk_abi::stake_contract();
+        let call_data = (TX_EXTEND, pk, signature).encode_to_vec();
+
+        let call = (contract_id, call_data);
+
+        let utx = UnprovenTransaction::new(
+            rng,
+            &self.state,
+            &sender,
+            inputs,
+            outputs,
+            fee,
+            (crossover, value, blinder),
+            Some(call),
+        )
+        .map_err(Error::from_state_err)?;
+
+        self.prover
+            .compute_proof_and_propagate(&utx)
+            .map_err(Error::from_prover_err)?;
+        Ok(())
     }
 
     /// Withdraw a key's stake.
-    pub fn withdraw_stake(&self) -> Result<(), Error<S, C>> {
-        unimplemented!()
-    }
+    pub fn withdraw_stake<Rng: RngCore + CryptoRng>(
+        &self,
+        rng: &mut Rng,
+        sender_index: u64,
+        staker_index: u64,
+        refund: &PublicSpendKey,
+        gas_limit: u64,
+        gas_price: u64,
+    ) -> Result<(), Error<S, SC, PC>> {
+        let sender = self
+            .store
+            .retrieve_ssk(sender_index)
+            .map_err(Error::from_store_err)?;
 
-    /// Syncs the wallet with the blocks.
-    pub fn sync_blocks(&self) -> Result<(), Error<S, C>> {
-        unimplemented!()
+        let inputs =
+            self.minimum_inputs_with_value(&sender, gas_limit * gas_price)?;
+
+        let sk = self
+            .store
+            .retrieve_sk(staker_index)
+            .map_err(Error::from_store_err)?;
+        let pk = PublicKey::from(&sk);
+
+        let (stake, expiration) =
+            self.state.fetch_stake(&pk).map_err(Error::from_state_err)?;
+
+        let output_note =
+            Note::transparent(rng, &sender.public_spend_key(), stake);
+        let note_blinder = output_note
+            .blinding_factor(None)
+            .expect("Note is transparent so blinding factor is unencrypted");
+
+        let fee = Fee::new(rng, gas_limit, gas_price, refund);
+
+        let blinder = JubJubScalar::random(rng);
+        let note =
+            Note::obfuscated(rng, &sender.public_spend_key(), stake, blinder);
+        let (_, crossover) = note
+            .try_into()
+            .expect("Obfuscated notes should always yield crossovers");
+
+        let outputs = vec![(output_note, stake, note_blinder)];
+
+        let proof = self
+            .prover
+            .request_wfct_proof(
+                crossover.value_commitment().into(),
+                stake,
+                blinder,
+            )
+            .map_err(Error::from_prover_err)?;
+
+        let message = BlsScalar::from(expiration as u64);
+        let signature = Signature::new(&sk, rng, message);
+
+        let contract_id = rusk_abi::stake_contract();
+        let call_data =
+            (TX_WITHDRAW, pk, signature, output_note, proof.to_bytes())
+                .encode_to_vec();
+
+        let call = (contract_id, call_data);
+
+        let utx = UnprovenTransaction::new(
+            rng,
+            &self.state,
+            &sender,
+            inputs,
+            outputs,
+            fee,
+            (crossover, stake, blinder),
+            Some(call),
+        )
+        .map_err(Error::from_state_err)?;
+
+        self.prover
+            .compute_proof_and_propagate(&utx)
+            .map_err(Error::from_prover_err)?;
+        Ok(())
     }
 
     /// Gets the balance of a key.
-    pub fn get_balance(&self, key_index: u64) -> Result<u64, Error<S, C>> {
+    pub fn get_balance(&self, ssk_index: u64) -> Result<u64, Error<S, SC, PC>> {
         let sender = self
             .store
-            .retrieve_key(key_index)
+            .retrieve_ssk(ssk_index)
             .map_err(Error::from_store_err)?;
         let vk = sender.view_key();
 
         let notes = self
-            .node
+            .state
             .fetch_notes(0, &vk)
-            .map_err(|e| Error::from_node_err(e))?;
+            .map_err(Error::from_state_err)?;
 
         let mut balance = 0;
         for note in notes.iter() {
@@ -247,6 +494,30 @@ where
 
         Ok(balance)
     }
+
+    /// Gets the stake and the expiration of said stake for a key.
+    pub fn get_stake(
+        &self,
+        sk_index: u64,
+    ) -> Result<(u64, u32), Error<S, SC, PC>> {
+        let sk = self
+            .store
+            .retrieve_sk(sk_index)
+            .map_err(Error::from_store_err)?;
+        let pk = PublicKey::from(&sk);
+
+        let s = self.state.fetch_stake(&pk).map_err(Error::from_state_err)?;
+        Ok(s)
+    }
+}
+
+fn contract_to_scalar(id: &ContractId) -> BlsScalar {
+    let mut scalar = [0; 32];
+    scalar.copy_from_slice(id.as_bytes());
+
+    scalar[31] &= 0x3f;
+
+    BlsScalar::from_bytes(&scalar).unwrap_or_default()
 }
 
 /// Since there is no link in the current circuit between the crossover

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,12 @@ mod imp;
 mod tx;
 
 use alloc::vec::Vec;
-use dusk_jubjub::BlsScalar;
-use dusk_pki::{SecretSpendKey, ViewKey};
+use dusk_jubjub::{BlsScalar, JubJubAffine, JubJubScalar};
+use dusk_pki::{PublicKey, SecretKey, SecretSpendKey, ViewKey};
+use dusk_plonk::proof_system::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
-use phoenix_core::Note;
+use dusk_schnorr::Signature;
+use phoenix_core::{Crossover, Fee, Note};
 use rand_chacha::ChaCha12Rng;
 use rand_core::SeedableRng;
 use sha2::{Digest, Sha256};
@@ -41,28 +43,41 @@ pub trait Store {
     /// Retrieves the seed used to derive keys.
     fn get_seed(&self) -> Result<[u8; 64], Self::Error>;
 
-    /// Retrieves a derived key from the store.
+    /// Retrieves a derived secret spend key from the store.
     ///
     /// The provided implementation simply gets the seed and regenerates the key
     /// every time with [`generate_ssk`]. It may be reimplemented to
     /// provide a cache for keys, or implement a different key generation
     /// algorithm.
-    fn retrieve_key(&self, index: u64) -> Result<SecretSpendKey, Self::Error> {
+    fn retrieve_ssk(&self, index: u64) -> Result<SecretSpendKey, Self::Error> {
         let seed = self.get_seed()?;
-        Ok(generate_ssk(&seed, index))
+        Ok(derive_ssk(&seed, index))
+    }
+
+    /// Retrieves a derived secret key from the store.
+    ///
+    /// The provided implementation simply gets the seed and regenerates the key
+    /// every time with [`generate_sk`]. It may be reimplemented to
+    /// provide a cache for keys, or implement a different key generation
+    /// algorithm.
+    fn retrieve_sk(&self, index: u64) -> Result<SecretKey, Self::Error> {
+        let seed = self.get_seed()?;
+        Ok(derive_sk(&seed, index))
     }
 }
 
-/// Generates a secret key from its seed and index.
+/// Generates a secret spend key from its seed and index.
 ///
 /// First the `seed` and then the little-endian representation of the key's
-/// `index` are passed through SHA-256. The resulting hash is then used to seed
-/// a `ChaCha12` CSPRNG, which is subsequently used to generate the key.
-pub fn generate_ssk(seed: &[u8; 64], index: u64) -> SecretSpendKey {
+/// `index` are passed through SHA-256. A constant is then mixed in and the
+/// resulting hash is then used to seed a `ChaCha12` CSPRNG, which is
+/// subsequently used to generate the key.
+pub fn derive_ssk(seed: &[u8; 64], index: u64) -> SecretSpendKey {
     let mut hash = Sha256::new();
 
     hash.update(&seed);
     hash.update(&index.to_le_bytes());
+    hash.update(b"SSK");
 
     let hash = hash.finalize().into();
     let mut rng = ChaCha12Rng::from_seed(hash);
@@ -70,8 +85,58 @@ pub fn generate_ssk(seed: &[u8; 64], index: u64) -> SecretSpendKey {
     SecretSpendKey::random(&mut rng)
 }
 
-/// Types that are clients of the node's API.
-pub trait NodeClient {
+/// Generates a secret key from its seed and index.
+///
+/// First the `seed` and then the little-endian representation of the key's
+/// `index` are passed through SHA-256. A constant is then mixed in and the
+/// resulting hash is then used to seed a `ChaCha12` CSPRNG, which is
+/// subsequently used to generate the key.
+pub fn derive_sk(seed: &[u8; 64], index: u64) -> SecretKey {
+    let mut hash = Sha256::new();
+
+    hash.update(&seed);
+    hash.update(&index.to_le_bytes());
+    hash.update(b"SK");
+
+    let hash = hash.finalize().into();
+    let mut rng = ChaCha12Rng::from_seed(hash);
+
+    SecretKey::random(&mut rng)
+}
+
+/// Types that are client of the prover.
+pub trait ProverClient {
+    /// Error returned by the node client.
+    type Error;
+
+    /// Requests that a node prove the given transaction and later propagates it
+    fn compute_proof_and_propagate(
+        &self,
+        utx: &UnprovenTransaction,
+    ) -> Result<(), Self::Error>;
+
+    /// Requests an STCT proof.
+    fn request_stct_proof(
+        &self,
+        fee: &Fee,
+        crossover: &Crossover,
+        value: u64,
+        blinder: JubJubScalar,
+        address: BlsScalar,
+        signature: Signature,
+    ) -> Result<Proof, Self::Error>;
+
+    /// Request a WFCT proof.
+    fn request_wfct_proof(
+        &self,
+        commitment: JubJubAffine,
+        value: u64,
+        blinder: JubJubScalar,
+    ) -> Result<Proof, Self::Error>;
+}
+
+/// Types that are clients of the state API.
+pub trait StateClient {
     /// Error returned by the node client.
     type Error;
 
@@ -91,9 +156,6 @@ pub trait NodeClient {
         note: &Note,
     ) -> Result<PoseidonBranch<POSEIDON_TREE_DEPTH>, Self::Error>;
 
-    /// Requests that a node prove the given transaction and later propagates it
-    fn compute_proof_and_propagate(
-        &self,
-        utx: &UnprovenTransaction,
-    ) -> Result<(), Self::Error>;
+    /// Queries the node the amount staked by a key and its expiration.
+    fn fetch_stake(&self, pk: &PublicKey) -> Result<(u64, u32), Self::Error>;
 }


### PR DESCRIPTION
This PR implements all staking transactions and makes some modifications to the trait system underlying the wallet. Namely splitting `NodeClient` into `ProverClient` and `StateClient` to better segregate responsibilities.

Proper testing is deferred to #11.

Resolves: #6