### PR TITLE
Publish WASM to Github NPM

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    tags:
+      - "v*.*.*"
     branches:
       - main
   pull_request:
@@ -71,6 +73,24 @@ jobs:
         with:
           command: rustc
           args: --release --target ${{ matrix.target }} -- -C link-args=-s
+
+      - name: Set up node
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com
+
+      - name: Publish package
+        if: startsWith(github.ref, 'refs/tags/v')
+        # Move the compiled package to the root for better paths in the npm module.
+        # We also automatically populate the version with the given tag.
+        run: >
+          mv target/wasm32-unknown-unknown/release/dusk_wallet_core.wasm mod.wasm &&
+          sed -i "/\"version\": \"0.0.1\"/s/\"0.0.1\"/\"${GITHUB_REF:11}\"/" package.json &&
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_and_test:
     name: Test with all features

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@dusk-network/wallet-core",
+  "version": "0.0.1",
+  "files": ["mod.wasm"],
+  "repository": "git://github.com/dusk-network/wallet-core",
+  "publishConfig": {
+    "@dusk-network:registry": "https://npm.pkg.github.com"
+  }
+}


### PR DESCRIPTION
This PR makes it so that the WASM binary produced by the CI gets published to NPM any time a new version tag is pushed.