### PR TITLE
Fix "RuntimeError: memory access out of bounds" error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -287,7 +287,7 @@ impl StateClient for FfiStateClient {
         height: u64,
         vk: &ViewKey,
     ) -> Result<Vec<Note>, Self::Error> {
-        let mut notes_buf = [0u8; NOTES_BUF_SIZE];
+        let mut notes_buf = vec![0u8; NOTES_BUF_SIZE];
 
         let mut num_notes = 0;
 


### PR DESCRIPTION
**Note**

The version `0.5.0` should be yanked after `0.5.1` is released.

- Change the allocation of the notes buffer from the stack to the heap

    The size was to big for the stack, causing a stack overflow (in WASM
    terms, "RuntimeError: memory access out of bounds").
    This is a quick fix, we should probably let the host decided via
    `malloc` how much memory to allocate.

- Bump to `0.5.1`

Resolves: #25