### PR TITLE
Fix `Canon` encoding of `Transaction`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dusk-bls12_381-sign = { version = "0.1.0-rc", default-features = false, features
 
 [dev-dependencies]
 rand = "^0.8"
+canonical_derive = "0.6"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -45,6 +45,7 @@ impl Canon for Transaction {
         self.anchor.encode(sink);
         self.nullifiers.encode(sink);
         self.fee.encode(sink);
+        1u8.encode(sink); // required due `Call` having an `Option<Crossover`.
         self.crossover.encode(sink);
         self.outputs.encode(sink);
         self.proof.encode(sink);
@@ -54,14 +55,25 @@ impl Canon for Transaction {
     fn decode(source: &mut Source) -> Result<Self, CanonError> {
         u8::decode(source)?;
 
+        let anchor = Canon::decode(source)?;
+        let nullifiers = Canon::decode(source)?;
+        let fee = Canon::decode(source)?;
+
+        u8::decode(source)?;
+
+        let crossover = Canon::decode(source)?;
+        let outputs = Canon::decode(source)?;
+        let proof = Canon::decode(source)?;
+        let call = Canon::decode(source)?;
+
         Ok(Transaction {
-            anchor: Canon::decode(source)?,
-            nullifiers: Canon::decode(source)?,
-            fee: Canon::decode(source)?,
-            crossover: Canon::decode(source)?,
-            outputs: Canon::decode(source)?,
-            proof: Canon::decode(source)?,
-            call: Canon::decode(source)?,
+            anchor,
+            nullifiers,
+            fee,
+            crossover,
+            outputs,
+            proof,
+            call,
         })
     }
 
@@ -71,6 +83,7 @@ impl Canon for Transaction {
             + self.anchor.encoded_len()
             + self.nullifiers.encoded_len()
             + self.fee.encoded_len()
+            + 1u8.encoded_len()
             + self.crossover.encoded_len()
             + self.outputs.encoded_len()
             + self.proof.encoded_len()

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -8,85 +8,29 @@
 
 mod mock;
 
-use dusk_jubjub::{JubJubAffine, JubJubScalar};
-use mock::{mock_wallet, TestProverClient};
-
-use dusk_bls12_381_sign::Signature;
-use dusk_plonk::prelude::{BlsScalar, Proof};
-use dusk_wallet_core::{ProverClient, UnprovenTransaction};
-use phoenix_core::{Crossover, Fee};
-
-#[derive(Debug)]
-struct SerdeProverClient {
-    prover: TestProverClient,
-}
-
-impl ProverClient for SerdeProverClient {
-    type Error = ();
-
-    fn compute_proof_and_propagate(
-        &self,
-        utx: &UnprovenTransaction,
-    ) -> Result<(), Self::Error> {
-        let utx_bytes = utx.to_var_bytes();
-        let utx_clone = UnprovenTransaction::from_slice(&utx_bytes)
-            .expect("Successful deserialization");
-
-        for (input, cinput) in
-            utx.inputs().iter().zip(utx_clone.inputs().iter())
-        {
-            assert_eq!(input.nullifier(), cinput.nullifier());
-            // assert_eq!(input.opening(), cinput.opening());
-            assert_eq!(input.note(), cinput.note());
-            assert_eq!(input.value(), cinput.value());
-            assert_eq!(input.blinding_factor(), cinput.blinding_factor());
-            assert_eq!(input.pk_r_prime(), cinput.pk_r_prime());
-            // assert_eq!(input.signature(), cinput.signature());
-        }
-
-        for (output, coutput) in
-            utx.outputs().iter().zip(utx_clone.outputs().iter())
-        {
-            assert_eq!(output, coutput);
-        }
-
-        assert_eq!(utx.anchor(), utx_clone.anchor());
-        assert_eq!(utx.fee(), utx_clone.fee());
-        assert_eq!(utx.crossover(), utx_clone.crossover());
-        assert_eq!(utx.call(), utx_clone.call());
-
-        self.prover.compute_proof_and_propagate(utx)
-    }
-
-    fn request_stct_proof(
-        &self,
-        fee: &Fee,
-        crossover: &Crossover,
-        value: u64,
-        blinder: JubJubScalar,
-        address: BlsScalar,
-        signature: Signature,
-    ) -> Result<Proof, Self::Error> {
-        self.prover.request_stct_proof(
-            fee, crossover, value, blinder, address, signature,
-        )
-    }
-
-    fn request_wfct_proof(
-        &self,
-        commitment: JubJubAffine,
-        value: u64,
-        blinder: JubJubScalar,
-    ) -> Result<Proof, Self::Error> {
-        self.prover.request_wfct_proof(commitment, value, blinder)
-    }
-}
+use dusk_plonk::prelude::BlsScalar;
+use mock::{mock_canon_wallet, mock_serde_wallet, mock_wallet};
 
 #[test]
 fn serde() {
     let mut rng = rand::thread_rng();
 
-    let wallet = mock_wallet(&mut rng, &[2500, 2500, 5000]);
+    let wallet = mock_serde_wallet(&mut rng, &[2500, 2500, 5000]);
+
+    let send_psk = wallet.public_spend_key(0).unwrap();
+    let recv_psk = wallet.public_spend_key(1).unwrap();
+
+    let ref_id = BlsScalar::random(&mut rng);
+    wallet
+        .transfer(&mut rng, 0, &send_psk, &recv_psk, 100, 100, 1, ref_id)
+        .expect("Transaction creation to be successful");
+}
+
+#[test]
+fn canon() {
+    let mut rng = rand::thread_rng();
+
+    let wallet = mock_canon_wallet(&mut rng, &[2500, 2500, 5000]);
 
     let send_psk = wallet.public_spend_key(0).unwrap();
     let recv_psk = wallet.public_spend_key(1).unwrap();


### PR DESCRIPTION
The transaction is required to encode into a `Canon` representation that
is equivalent to the one of `transfer-contract::Call::Execute`. This
ensures that it can pass directly through the virtual machine.

Resolves: #31