### PR TITLE
Optional crossover

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.7.0-rc.1"
+version = "0.8.0-rc.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -107,7 +107,7 @@ impl Transaction {
 
     /// Serializes the transaction into a variable length byte buffer.
     #[allow(unused_must_use)]
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_var_bytes(&self) -> Vec<u8> {
         // compute the serialized size to preallocate space
         let size = u64::SIZE
             + self.nullifiers.len() * BlsScalar::SIZE


### PR DESCRIPTION
 Change crossover to optional
    
Crossovers should be optional in both `UnprovenTransaction`s and `Transaction`s due to the fact that they're only used when transferring value between contract boundaries. A regular transfer transaction doesn't need them.

