### PR TITLE
Fix notes from `fetch_notes` being assumed unspent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.8.0-rc.3"
+version = "0.9.0-rc.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,13 @@ pub trait StateClient {
     /// Fetch the current anchor of the state.
     fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error>;
 
+    /// Asks the node to return the nullifiers that already exist from the given
+    /// nullifiers.
+    fn fetch_existing_nullifiers(
+        &self,
+        nullifiers: &[BlsScalar],
+    ) -> Result<Vec<BlsScalar>, Self::Error>;
+
     /// Queries the node to find the opening for a specific note.
     fn fetch_opening(
         &self,

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -161,6 +161,13 @@ impl StateClient for TestStateClient {
         Ok(self.anchor)
     }
 
+    fn fetch_existing_nullifiers(
+        &self,
+        _: &[BlsScalar],
+    ) -> Result<Vec<BlsScalar>, Self::Error> {
+        Ok(vec![])
+    }
+
     fn fetch_opening(
         &self,
         _: &Note,


### PR DESCRIPTION
This is done by:

- Add `fetch_existing_nullifiers` to the state client. This returns,
  given a list of nullifiers, the ones already present in the state.

- Change the functions already using `fetch_notes` to use a new function
  `unspent_notes`. This function filters the notes who's nullifiers are
  already present in the state, effectively returning only notes that
  are not already spent.

Resolves: #41