### PR TITLE
Change transacting functions to return transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.9.0-rc.0"
+version = "0.10.0-rc.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::tx::UnprovenTransaction;
-use crate::{ProverClient, StateClient, Store};
+use crate::{ProverClient, StateClient, Store, Transaction};
 
 use alloc::vec::Vec;
 
@@ -263,7 +263,7 @@ where
         gas_limit: u64,
         gas_price: u64,
         ref_id: BlsScalar,
-    ) -> Result<(), Error<S, SC, PC>> {
+    ) -> Result<Transaction, Error<S, SC, PC>> {
         let sender = self
             .store
             .retrieve_ssk(sender_index)
@@ -298,9 +298,7 @@ where
 
         self.prover
             .compute_proof_and_propagate(&utx)
-            .map_err(Error::from_prover_err)?;
-
-        Ok(())
+            .map_err(Error::from_prover_err)
     }
 
     /// Stakes an amount of Dusk.
@@ -314,7 +312,7 @@ where
         value: u64,
         gas_limit: u64,
         gas_price: u64,
-    ) -> Result<(), Error<S, SC, PC>> {
+    ) -> Result<Transaction, Error<S, SC, PC>> {
         let sender = self
             .store
             .retrieve_ssk(sender_index)
@@ -383,8 +381,7 @@ where
 
         self.prover
             .compute_proof_and_propagate(&utx)
-            .map_err(Error::from_prover_err)?;
-        Ok(())
+            .map_err(Error::from_prover_err)
     }
 
     /// Extends staking for a particular key.
@@ -396,7 +393,7 @@ where
         refund: &PublicSpendKey,
         gas_limit: u64,
         gas_price: u64,
-    ) -> Result<(), Error<S, SC, PC>> {
+    ) -> Result<Transaction, Error<S, SC, PC>> {
         let sender = self
             .store
             .retrieve_ssk(sender_index)
@@ -443,8 +440,7 @@ where
 
         self.prover
             .compute_proof_and_propagate(&utx)
-            .map_err(Error::from_prover_err)?;
-        Ok(())
+            .map_err(Error::from_prover_err)
     }
 
     /// Withdraw a key's stake.
@@ -456,7 +452,7 @@ where
         refund: &PublicSpendKey,
         gas_limit: u64,
         gas_price: u64,
-    ) -> Result<(), Error<S, SC, PC>> {
+    ) -> Result<Transaction, Error<S, SC, PC>> {
         let sender = self
             .store
             .retrieve_ssk(sender_index)
@@ -529,8 +525,7 @@ where
 
         self.prover
             .compute_proof_and_propagate(&utx)
-            .map_err(Error::from_prover_err)?;
-        Ok(())
+            .map_err(Error::from_prover_err)
     }
 
     /// Gets the balance of a key.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub trait ProverClient {
     fn compute_proof_and_propagate(
         &self,
         utx: &UnprovenTransaction,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<Transaction, Self::Error>;
 
     /// Requests an STCT proof.
     fn request_stct_proof(

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -187,9 +187,9 @@ impl ProverClient for TestProverClient {
     type Error = ();
     fn compute_proof_and_propagate(
         &self,
-        _: &UnprovenTransaction,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+        utx: &UnprovenTransaction,
+    ) -> Result<Transaction, Self::Error> {
+        Ok(utx.clone().prove(Proof::default()))
     }
 
     fn request_stct_proof(
@@ -242,7 +242,7 @@ impl ProverClient for CanonProverClient {
     fn compute_proof_and_propagate(
         &self,
         utx: &UnprovenTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Transaction, Self::Error> {
         let utx_clone = utx.clone();
 
         let tx = utx_clone.prove(Proof::default());
@@ -293,7 +293,7 @@ impl ProverClient for SerdeProverClient {
     fn compute_proof_and_propagate(
         &self,
         utx: &UnprovenTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Transaction, Self::Error> {
         let utx_bytes = utx.to_var_bytes();
         let utx_clone = UnprovenTransaction::from_slice(&utx_bytes)
             .expect("Successful deserialization");


### PR DESCRIPTION
Requires the `ProverClient` to return the transaction in
`compute_proof_and_propagate`. This entails a change in the FFI as well
since the implementation of the traits is deferred to the user.

Resolves #40 