### PR TITLE
Fix `encoded_len` of `Transaction`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -76,12 +76,12 @@ impl Canon for Transaction {
     fn encoded_len(&self) -> usize {
         0u8.encoded_len()
             + self.anchor.encoded_len()
-            + self.anchor.encoded_len()
             + self.nullifiers.encoded_len()
             + self.fee.encoded_len()
             + self.crossover.encoded_len()
             + self.outputs.encoded_len()
             + self.proof.encoded_len()
+            + self.call.encoded_len()
     }
 }
 


### PR DESCRIPTION
The previous implementation yields incorrect length for a transaction
containing a contract call.

Resolves: #44