### PR TITLE
Upgrade to conform to new stake contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.10.0-rc.1"
+version = "0.11.0-rc.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -15,8 +15,8 @@ use dusk_plonk::prelude::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
 use dusk_wallet_core::{
-    ProverClient, StateClient, Store, Transaction, UnprovenTransaction, Wallet,
-    POSEIDON_TREE_DEPTH,
+    ProverClient, StakeInfo, StateClient, Store, Transaction,
+    UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
 };
 use phoenix_core::{Crossover, Fee, Note, NoteType};
 use rand_core::{CryptoRng, RngCore};
@@ -175,8 +175,16 @@ impl StateClient for TestStateClient {
         Ok(self.opening.clone())
     }
 
-    fn fetch_stake(&self, _pk: &PublicKey) -> Result<(u64, u64), Self::Error> {
-        Ok((100, 200))
+    fn fetch_stake(&self, _pk: &PublicKey) -> Result<StakeInfo, Self::Error> {
+        Ok(StakeInfo {
+            value: 100,
+            eligibility: 0,
+            created_at: 0,
+        })
+    }
+
+    fn fetch_block_height(&self) -> Result<u64, Self::Error> {
+        Ok(1)
     }
 }
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -8,8 +8,27 @@
 
 mod mock;
 
+use dusk_bytes::Serializable;
 use dusk_plonk::prelude::BlsScalar;
+use dusk_wallet_core::StakeInfo;
 use mock::{mock_canon_wallet, mock_serde_wallet, mock_wallet};
+
+#[test]
+fn serde_stake() {
+    let stake = StakeInfo {
+        value: 0x4321,
+        eligibility: 0x1234,
+        created_at: 0x9876,
+    };
+
+    let stake_bytes = stake.to_bytes();
+    let des_stake =
+        StakeInfo::from_bytes(&stake_bytes).expect("serde to go correctly");
+
+    assert_eq!(stake.value, des_stake.value);
+    assert_eq!(stake.eligibility, des_stake.eligibility);
+    assert_eq!(stake.created_at, des_stake.created_at);
+}
 
 #[test]
 fn serde() {


### PR DESCRIPTION
Upgrade to conform to new stake contract
    
- Modify `StateClient` to be able to receive full stake info and query
  the node for the current block height.
- Remove extend stake since the contract no longer supports it.
- Change implementation of stake and withdraw to conform to new stake
  contract.
    
Resolves: #46