### PR TITLE
Change `get_balance` to also return max spendable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.12.0-rc.0"
+version = "0.13.0-rc.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -29,8 +29,8 @@ use rand_core::{
 
 use crate::tx::UnprovenTransaction;
 use crate::{
-    Error, ProverClient, StakeInfo, StateClient, Store, Transaction, Wallet,
-    POSEIDON_TREE_DEPTH,
+    BalanceInfo, Error, ProverClient, StakeInfo, StateClient, Store,
+    Transaction, Wallet, POSEIDON_TREE_DEPTH,
 };
 
 extern "C" {
@@ -231,8 +231,12 @@ pub unsafe extern "C" fn withdraw_stake(
 
 /// Gets the balance of a secret spend key.
 #[no_mangle]
-pub unsafe extern "C" fn get_balance(ssk_index: u64, balance: *mut u64) -> u8 {
-    *balance = unwrap_or_bail!(WALLET.get_balance(ssk_index));
+pub unsafe extern "C" fn get_balance(
+    ssk_index: u64,
+    balance: *mut [u8; BalanceInfo::SIZE],
+) -> u8 {
+    let b = unwrap_or_bail!(WALLET.get_balance(ssk_index)).to_bytes();
+    ptr::copy_nonoverlapping(&b[0], &mut (*balance)[0], b.len());
     0
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,42 @@ pub trait StateClient {
     fn fetch_block_height(&self) -> Result<u64, Self::Error>;
 }
 
+/// Information about the balance of a particular key.
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+pub struct BalanceInfo {
+    /// The total value of the balance.
+    pub value: u64,
+    /// The maximum _spendable_ value in a single transaction. This is
+    /// different from `value` since there is a maximum number of notes one can
+    /// spend.
+    pub spendable: u64,
+}
+
+impl Serializable<16> for BalanceInfo {
+    type Error = dusk_bytes::Error;
+
+    fn from_bytes(buf: &[u8; Self::SIZE]) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        let mut reader = &buf[..];
+
+        let value = u64::from_reader(&mut reader)?;
+        let spendable = u64::from_reader(&mut reader)?;
+
+        Ok(Self { value, spendable })
+    }
+
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+
+        buf[0..8].copy_from_slice(&self.value.to_bytes());
+        buf[8..16].copy_from_slice(&self.spendable.to_bytes());
+
+        buf
+    }
+}
+
 /// The stake of a particular key.
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
 pub struct StakeInfo {

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -79,8 +79,9 @@ fn transfer() {
 fn get_balance() {
     let mut rng = rand::thread_rng();
 
-    let wallet = mock_wallet(&mut rng, &[2500, 2500, 5000]);
-    let balance = wallet.get_balance(0).expect("Valid balance call");
+    let wallet = mock_wallet(&mut rng, &[2500, 5000, 2500, 5000, 5000]);
+    let info = wallet.get_balance(0).expect("Valid balance call");
 
-    assert_eq!(balance, 10000);
+    assert_eq!(info.value, 20000);
+    assert_eq!(info.spendable, 17500);
 }


### PR DESCRIPTION
The `BalanceInfo` struct is introduced, returned by `get_balance` and
contains both the total balance available, and the maximum amount
spendable in a single transaction.

Resolves: #53