### PR TITLE
Change `fetch_notes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.14.1-rc.1"
+version = "0.15.0-rc.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,8 +30,8 @@ use rusk_abi::ContractId;
 
 use crate::tx::UnprovenTransaction;
 use crate::{
-    BalanceInfo, Error, ProverClient, StakeInfo, StateClient, Store,
-    Transaction, Wallet, POSEIDON_TREE_DEPTH,
+    BalanceInfo, EnrichedNote, Error, ProverClient, StakeInfo, StateClient,
+    Store, Transaction, Wallet, POSEIDON_TREE_DEPTH,
 };
 
 extern "C" {
@@ -353,7 +353,7 @@ impl StateClient for FfiStateClient {
     fn fetch_notes(
         &self,
         vk: &ViewKey,
-    ) -> Result<Vec<(Note, u64)>, Self::Error> {
+    ) -> Result<Vec<EnrichedNote>, Self::Error> {
         let mut notes_ptr = ptr::null_mut();
         let mut notes_len = 0;
 

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -205,7 +205,7 @@ where
             self.state.fetch_notes(&vk).map_err(Error::from_state_err)?;
 
         let nullifiers: Vec<_> =
-            notes.iter().map(|n| n.gen_nullifier(ssk)).collect();
+            notes.iter().map(|(n, _)| n.gen_nullifier(ssk)).collect();
 
         let existing_nullifiers = self
             .state
@@ -216,7 +216,7 @@ where
             .into_iter()
             .zip(nullifiers.into_iter())
             .filter(|(_, nullifier)| !existing_nullifiers.contains(nullifier))
-            .map(|(note, _)| note)
+            .map(|((note, _), _)| note)
             .collect();
 
         Ok(unspent_notes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,12 @@ pub trait ProverClient {
     ) -> Result<Proof, Self::Error>;
 }
 
+/// Block height representation
+pub type BlockHeight = u64;
+
+/// Tuple containing Note and Block height
+pub type EnrichedNote = (Note, BlockHeight);
+
 /// Types that are clients of the state API.
 pub trait StateClient {
     /// Error returned by the node client.
@@ -146,7 +152,7 @@ pub trait StateClient {
     fn fetch_notes(
         &self,
         vk: &ViewKey,
-    ) -> Result<Vec<(Note, u64)>, Self::Error>;
+    ) -> Result<Vec<EnrichedNote>, Self::Error>;
 
     /// Fetch the current anchor of the state.
     fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,10 @@ pub trait StateClient {
     type Error;
 
     /// Find notes for a view key.
-    fn fetch_notes(&self, vk: &ViewKey) -> Result<Vec<Note>, Self::Error>;
+    fn fetch_notes(
+        &self,
+        vk: &ViewKey,
+    ) -> Result<Vec<(Note, u64)>, Self::Error>;
 
     /// Fetch the current anchor of the state.
     fn fetch_anchor(&self) -> Result<BlsScalar, Self::Error>;

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -90,12 +90,12 @@ fn new_notes<Rng: RngCore + CryptoRng>(
     rng: &mut Rng,
     psk: &PublicSpendKey,
     note_values: &[u64],
-) -> Vec<Note> {
+) -> Vec<(Note, u64)> {
     note_values
         .iter()
         .map(|val| {
             let blinder = JubJubScalar::random(rng);
-            Note::new(rng, NoteType::Obfuscated, psk, *val, blinder)
+            (Note::new(rng, NoteType::Obfuscated, psk, *val, blinder), 0)
         })
         .collect()
 }
@@ -126,7 +126,7 @@ impl Store for TestStore {
 /// A state client that always returns the same notes, anchor, and opening.
 #[derive(Debug, Clone)]
 pub struct TestStateClient {
-    notes: Vec<Note>,
+    notes: Vec<(Note, u64)>,
     anchor: BlsScalar,
     opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
 }
@@ -134,7 +134,7 @@ pub struct TestStateClient {
 impl TestStateClient {
     /// Create a new node given the notes, anchor, and opening we will return.
     fn new(
-        notes: Vec<Note>,
+        notes: Vec<(Note, u64)>,
         anchor: BlsScalar,
         opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
     ) -> Self {
@@ -149,7 +149,10 @@ impl TestStateClient {
 impl StateClient for TestStateClient {
     type Error = ();
 
-    fn fetch_notes(&self, _: &ViewKey) -> Result<Vec<Note>, Self::Error> {
+    fn fetch_notes(
+        &self,
+        _: &ViewKey,
+    ) -> Result<Vec<(Note, u64)>, Self::Error> {
         Ok(self.notes.clone())
     }
 

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -15,7 +15,7 @@ use dusk_plonk::prelude::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
 use dusk_wallet_core::{
-    ProverClient, StakeInfo, StateClient, Store, Transaction,
+    EnrichedNote, ProverClient, StakeInfo, StateClient, Store, Transaction,
     UnprovenTransaction, Wallet, POSEIDON_TREE_DEPTH,
 };
 use phoenix_core::{Crossover, Fee, Note, NoteType};
@@ -90,7 +90,7 @@ fn new_notes<Rng: RngCore + CryptoRng>(
     rng: &mut Rng,
     psk: &PublicSpendKey,
     note_values: &[u64],
-) -> Vec<(Note, u64)> {
+) -> Vec<EnrichedNote> {
     note_values
         .iter()
         .map(|val| {
@@ -126,7 +126,7 @@ impl Store for TestStore {
 /// A state client that always returns the same notes, anchor, and opening.
 #[derive(Debug, Clone)]
 pub struct TestStateClient {
-    notes: Vec<(Note, u64)>,
+    notes: Vec<EnrichedNote>,
     anchor: BlsScalar,
     opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
 }
@@ -134,7 +134,7 @@ pub struct TestStateClient {
 impl TestStateClient {
     /// Create a new node given the notes, anchor, and opening we will return.
     fn new(
-        notes: Vec<(Note, u64)>,
+        notes: Vec<EnrichedNote>,
         anchor: BlsScalar,
         opening: PoseidonBranch<POSEIDON_TREE_DEPTH>,
     ) -> Self {
@@ -152,7 +152,7 @@ impl StateClient for TestStateClient {
     fn fetch_notes(
         &self,
         _: &ViewKey,
-    ) -> Result<Vec<(Note, u64)>, Self::Error> {
+    ) -> Result<Vec<EnrichedNote>, Self::Error> {
         Ok(self.notes.clone())
     }
 


### PR DESCRIPTION
Instead of return a `Vec<Note>` the function now return a `Vec<(Note,BlockHeight)>` 
This is required by the wallet in order to implement the wallet history

See also dusk-network/wallet-cli#12