### PR TITLE
Pass in Secret key instead of view key to fetch_notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.15.0-rc.0"
+version = "0.15.0-rc.1"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -17,7 +17,7 @@ use dusk_bls12_381_sign::PublicKey;
 use dusk_bytes::Write;
 use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_jubjub::{BlsScalar, JubJubAffine, JubJubScalar};
-use dusk_pki::{PublicSpendKey, ViewKey};
+use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::prelude::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
@@ -51,7 +51,7 @@ extern "C" {
     ///
     /// E.g: note1, block_height, note2, block_height, etc...
     fn fetch_notes(
-        vk: *const [u8; ViewKey::SIZE],
+        vk: *const [u8; SecretSpendKey::SIZE],
         notes: *mut *mut u8,
         notes_len: *mut u32,
     ) -> u8;
@@ -352,7 +352,7 @@ impl StateClient for FfiStateClient {
 
     fn fetch_notes(
         &self,
-        vk: &ViewKey,
+        vk: &SecretSpendKey,
     ) -> Result<Vec<EnrichedNote>, Self::Error> {
         let mut notes_ptr = ptr::null_mut();
         let mut notes_len = 0;

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -199,10 +199,8 @@ where
         &self,
         ssk: &SecretSpendKey,
     ) -> Result<Vec<Note>, Error<S, SC, PC>> {
-        let vk = ssk.view_key();
-
         let notes =
-            self.state.fetch_notes(&vk).map_err(Error::from_state_err)?;
+            self.state.fetch_notes(ssk).map_err(Error::from_state_err)?;
 
         let nullifiers: Vec<_> =
             notes.iter().map(|(n, _)| n.gen_nullifier(ssk)).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use alloc::vec::Vec;
 use dusk_bls12_381_sign::{PublicKey, SecretKey};
 use dusk_bytes::{DeserializableSlice, Serializable, Write};
 use dusk_jubjub::{BlsScalar, JubJubAffine, JubJubScalar};
-use dusk_pki::{SecretSpendKey, ViewKey};
+use dusk_pki::SecretSpendKey;
 use dusk_plonk::proof_system::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
@@ -151,7 +151,7 @@ pub trait StateClient {
     /// Find notes for a view key.
     fn fetch_notes(
         &self,
-        vk: &ViewKey,
+        vk: &SecretSpendKey,
     ) -> Result<Vec<EnrichedNote>, Self::Error>;
 
     /// Fetch the current anchor of the state.

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -10,7 +10,7 @@ use canonical::{Canon, Sink, Source};
 use canonical_derive::Canon;
 use dusk_bls12_381_sign::PublicKey;
 use dusk_jubjub::{BlsScalar, JubJubAffine, JubJubScalar};
-use dusk_pki::{PublicSpendKey, ViewKey};
+use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::prelude::Proof;
 use dusk_poseidon::tree::PoseidonBranch;
 use dusk_schnorr::Signature;
@@ -151,7 +151,7 @@ impl StateClient for TestStateClient {
 
     fn fetch_notes(
         &self,
-        _: &ViewKey,
+        _: &SecretSpendKey,
     ) -> Result<Vec<EnrichedNote>, Self::Error> {
         Ok(self.notes.clone())
     }


### PR DESCRIPTION
In the future, Matteo mentioned we should fetch the notes of the addresses who's address is generated by the wallet seed or could be in the future and we keep that seed in the cache. 