### PR TITLE
Bump to v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2021-10-14
+
 ### Added
 
 - Add `asyncify`ing FFI imports
@@ -144,7 +146,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Releases -->
 
-[Unreleased]: https://github.com/dusk-network/wallet-core/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/dusk-network/wallet-core/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/dusk-network/wallet-core/compare/v0.5.1...v0.21.0
 [0.5.1]: https://github.com/dusk-network/wallet-core/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/wallet-core/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/wallet-core/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-wallet-core"
-version = "0.20.0-piecrust.0.6"
+version = "0.21.0"
 edition = "2021"
 description = "The core functionality of the Dusk wallet"
 license = "MPL-2.0"


### PR DESCRIPTION
## [0.21.0] - 2021-10-14

### Added

- Add `asyncify`ing FFI imports
- Add `unstake` function to allow unstaking a previously staked amount [#58]
- Add `fetch_existing_nullifiers` to the `StateClient` [#41]
- Add `ff` dependency at `0.13`

### Changed

- Change FFI to take pointers to `u64`
- Change `withdraw` function to withdraw the reward for staking and
  participating in the consensus [#58]
- Change `stake` and `withdraw` cryptographic signatures to what the stake
  contract expects in the new spec [#58]
- Change `StakeInfo` to have an optional amount staked, a reward, and a
  signature counter [#58]
- Change signature of `fetch_notes` by removing block height
- Change `fetch_notes` in the FFI to delegate buffer allocation to the user. [#58]
- Change note picker to pick the largest amount of notes possible, with the minimum
  total value [#55]
- Change `get_balance` to return total and max spendable [#53]
- Change `fetch_existing_nullifiers` in the FFI to return early [#49]
- Modify `StateClient` to receive full stake info [#46]
- Change `Canon` encoding length of `Transaction` [#31]
- Change transacting functions to return `Transaction` [#40]
- Update transaction to generate change output
- Change transactions to have an optional crossover
- Update STCT to use Schnorr signatures [#34]
- Update dependencies
- Update `phoenix-core` to `0.17`
- Update `dusk-pki` to `0.11`
- Update `dusk-schnorr` to `0.11`
- Update `dusk-jubjub` to `0.12`
- Update `dusk-poseidon` to `0.26`
- Update `dusk-plonk` to `0.12`
- Update `dusk-bls12_381-sign` to `0.4`
- Update dependencies
- Update `phoenix-core` `0.18` -> `0.20.0-rc.0`
- Update `dusk-pki` `0.11` -> `0.12`
- Update `dusk-schnorr` `0.12` -> `0.13`
- Update `dusk-poseidon` `0.29.1-rc.0` -> `0.30`
- Update `dusk-plonk` `0.13` -> `0.14`
- Change `dusk-merkle` dependency to `poseidon-merkle` after merkle crate separation
- Update `phoenix-core` `0.20.0-rc.0` -> `0.21`
- Update `dusk-pki` `0.12` -> `0.13`
- Update `dusk-schnorr` `0.13` -> `0.14`
- Update `dusk-poseidon` `0.30` -> `0.31`
- Update `dusk-plonk` `0.14` -> `0.16`
- Update `dusk-bls12_381-sign` `0.4` -> `0.5`
- Update `dusk-jubjub` `0.12` -> `0.13`
- Update `poseidon-merkle` `0.2.1-rc.0` -> `0.3`
- Update `rusk-abi` `0.10.0-piecrust.0.6` -> `0.11`

### Fixed

- Fix `encoded_len` in `Transaction` [#44]
- Fix notes from `fetch_notes` being assumed unspent [#41]
- Fix fee generation in stake and withdrawal

### Removed

- Remove `get_block_height` from the `StateClient` trait [#58]
- Delete `extend_stake` since the stake contract removed it [#46]

[0.21.0]: https://github.com/dusk-network/wallet-core/compare/v0.5.1...v0.21.0
